### PR TITLE
feat: Step 03 complete + OpenClaw install checklist + Step 04 doc agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ htmlcov/
 
 # Logs
 *.log
+
+# AI Office local logs (never commit — may contain operational data)
+ai-office-logs/

--- a/CAMPCLAW.md
+++ b/CAMPCLAW.md
@@ -34,11 +34,11 @@
 
 | Task | File | Status |
 |---|---|---|
-| Create `aioffice` macOS user + harden settings | [TASKS/0003](TASKS/0003-mac-mini-os-hardening.md) | Open |
-| Install toolchain (brew, git, node, docker, chrome, slack) | [TASKS/0004](TASKS/0004-mac-mini-tooling-install.md) | Open |
-| Create Chrome profiles for AI ops accounts | [TASKS/0005](TASKS/0005-mac-mini-chrome-profiles.md) | Open |
-| Create local logging directory + conventions | [TASKS/0006](TASKS/0006-mac-mini-logging-setup.md) | Open |
-| Install OpenClaw (not connected) | [TASKS/0010](TASKS/0010-openclaw-initial-install-not-connected.md) | Open |
+| Create `aioffice` macOS user + harden settings | [TASKS/0003](TASKS/0003-mac-mini-os-hardening.md) | ✅ Done |
+| Install toolchain (brew, git, node, docker, chrome, slack) | [TASKS/0004](TASKS/0004-mac-mini-tooling-install.md) | ✅ Done |
+| Create Chrome profiles for AI ops accounts | [TASKS/0005](TASKS/0005-mac-mini-chrome-profiles.md) | ✅ Done |
+| Create local logging directory + conventions | [TASKS/0006](TASKS/0006-mac-mini-logging-setup.md) | ✅ Done |
+| Install OpenClaw + connect to Slack | [TASKS/0013](TASKS/0013-openclaw-install-slack-connect.md) | 🔵 Active |
 
 **Step 03 Complete When:** OpenClaw is installed and connected to Slack or Discord.
 
@@ -48,10 +48,11 @@
 
 **CampClaw Artifact:** A fully configured agent with identity docs and behavior instructions.
 
-**Repo Artifacts to Create:**
-- Agent system prompt / behavior instructions (`AGENTS/`)
-- Identity document per agent role
-- Behavior instructions linked to [`POLICIES/ai-safety-charter.md`](POLICIES/ai-safety-charter.md)
+**First Agent:** Documentary Agent (`doc@appyhourlabs.com`) — lowest risk, self-documenting setup.
+
+| Task | File | Status |
+|---|---|---|
+| Configure doc agent in OpenClaw (system prompt, file access, first run) | [TASKS/0014](TASKS/0014-doc-agent-step04-configure.md) | Open |
 
 ---
 

--- a/PROJECTS/0002-mac-mini-ai-office-setup.md
+++ b/PROJECTS/0002-mac-mini-ai-office-setup.md
@@ -27,10 +27,11 @@ Configure the Mac Mini as a dedicated, hardened AI Office — a fixed, auditable
 
 | Task | File | Status |
 |---|---|---|
-| Create `aioffice` macOS user and harden settings | [`TASKS/0003`](../TASKS/0003-mac-mini-os-hardening.md) | Open |
-| Install tooling (brew, git, node, docker, chrome, slack) | [`TASKS/0004`](../TASKS/0004-mac-mini-tooling-install.md) | Open |
-| Create Chrome profiles for AI ops accounts | [`TASKS/0005`](../TASKS/0005-mac-mini-chrome-profiles.md) | Open |
-| Create local logging directory and conventions | [`TASKS/0006`](../TASKS/0006-mac-mini-logging-setup.md) | Complete |
+| Create `aioffice` macOS user and harden settings | [`TASKS/0003`](../TASKS/0003-mac-mini-os-hardening.md) | ✅ Done |
+| Install tooling (brew, git, node, docker, chrome, slack) | [`TASKS/0004`](../TASKS/0004-mac-mini-tooling-install.md) | ✅ Done |
+| Create Chrome profiles for AI ops accounts | [`TASKS/0005`](../TASKS/0005-mac-mini-chrome-profiles.md) | ✅ Done |
+| Create local logging directory and conventions | [`TASKS/0006`](../TASKS/0006-mac-mini-logging-setup.md) | ✅ Done |
+| Install OpenClaw + connect to Slack | [`TASKS/0013`](../TASKS/0013-openclaw-install-slack-connect.md) | 🔵 Active |
 
 ---
 

--- a/TASKS/0003-mac-mini-os-hardening.md
+++ b/TASKS/0003-mac-mini-os-hardening.md
@@ -3,7 +3,7 @@
 > **Project:** [0002 — Mac Mini AI Office Setup](../PROJECTS/0002-mac-mini-ai-office-setup.md)  
 > **Owner:** Human (`matt@appyhourlabs.com`)  
 > **Priority:** P0  
-> **Status:** Open
+> **Status:** Done
 
 ---
 
@@ -60,11 +60,11 @@ Create a non-admin macOS standard user account (`aioffice`) for running agent wo
 
 ## Definition of Done
 
-- [ ] `aioffice` standard user created, no admin rights
-- [ ] FileVault enabled; recovery key stored securely (location noted in handoff)
-- [ ] Firewall enabled and configured
-- [ ] All remote sharing services disabled
-- [ ] Login as `aioffice` verified
+- [x] `aioffice` standard user created, no admin rights
+- [x] FileVault enabled; recovery key stored securely (location noted in handoff)
+- [x] Firewall enabled and configured
+- [x] All remote sharing services disabled
+- [x] Login as `aioffice` verified
 
 ---
 

--- a/TASKS/0004-mac-mini-tooling-install.md
+++ b/TASKS/0004-mac-mini-tooling-install.md
@@ -3,7 +3,7 @@
 > **Project:** [0002 — Mac Mini AI Office Setup](../PROJECTS/0002-mac-mini-ai-office-setup.md)  
 > **Owner:** Human (`matt@appyhourlabs.com`) for install; AI (`ai@appyhourlabs.com`) for verification  
 > **Priority:** P1  
-> **Status:** Open
+> **Status:** Done
 
 ---
 
@@ -70,11 +70,11 @@ Install the standard AI Office toolchain: Homebrew, Git, Node 20, Docker, Chrome
 
 ## Definition of Done
 
-- [ ] All 6 tools installed and accessible
-- [ ] `git --version`, `node --version`, `docker --version` return expected versions
-- [ ] Chrome installed with no accounts signed in at the system level
-- [ ] Slack installed and workspace accessible
-- [ ] Verification passed under `aioffice` user account
+- [x] All 6 tools installed and accessible
+- [x] `git --version`, `node --version`, `docker --version` return expected versions
+- [x] Chrome installed with no accounts signed in at the system level
+- [x] Slack installed and workspace accessible
+- [x] Verification passed under `aioffice` user account
 
 ---
 

--- a/TASKS/0005-mac-mini-chrome-profiles.md
+++ b/TASKS/0005-mac-mini-chrome-profiles.md
@@ -3,7 +3,7 @@
 > **Project:** [0002 — Mac Mini AI Office Setup](../PROJECTS/0002-mac-mini-ai-office-setup.md)  
 > **Owner:** Human (`matt@appyhourlabs.com`)  
 > **Priority:** P1  
-> **Status:** Open
+> **Status:** Done
 
 ---
 
@@ -46,11 +46,11 @@ Create isolated Chrome browser profiles for each AI ops account (`ai@appyhourlab
 
 ## Definition of Done
 
-- [ ] 4 Chrome profiles created: `ai@appyhourlabs.com`, `sales@appyhourlabs.com`, `media@appyhourlabs.com`, `doc@appyhourlabs.com`
-- [ ] Each profile signed in to correct Google account
-- [ ] Cross-profile session isolation verified (sign-in to one doesn't affect another)
-- [ ] Profiles named and colored distinctly
-- [ ] Sync settings reviewed and minimized
+- [x] 4 Chrome profiles created: `ai@appyhourlabs.com`, `sales@appyhourlabs.com`, `media@appyhourlabs.com`, `doc@appyhourlabs.com`
+- [x] Each profile signed in to correct Google account
+- [x] Cross-profile session isolation verified (sign-in to one doesn't affect another)
+- [x] Profiles named and colored distinctly
+- [x] Sync settings reviewed and minimized
 
 ---
 

--- a/TASKS/0006-mac-mini-logging-setup.md
+++ b/TASKS/0006-mac-mini-logging-setup.md
@@ -66,11 +66,11 @@ Create a local logging directory on the AI Office Mac Mini for agent action logs
 
 ## Definition of Done
 
-- [ ] `~/ai-office-logs/agents/`, `/pipelines/`, `/incidents/` directories created
-- [ ] Permissions set to owner-only write
+- [x] `~/ai-office-logs/agents/`, `/pipelines/`, `/incidents/` directories created
+- [x] Permissions set to owner-only write (`drwx------`, owned by `aioffice`)
 - [x] `RUNBOOKS/logging-conventions.md` written with the required log schema
-- [ ] `.gitignore` excludes local log paths
-- [ ] Test log entry created and verified
+- [x] `.gitignore` excludes local log paths (`ai-office-logs/` added)
+- [x] Test log entry created and verified (`agents/test-entry.json`)
 
 ---
 

--- a/TASKS/0013-openclaw-install-slack-connect.md
+++ b/TASKS/0013-openclaw-install-slack-connect.md
@@ -1,0 +1,147 @@
+# Task 0013 — Install OpenClaw and Connect to Slack
+
+> **Project:** [0002 — Mac Mini AI Office Setup](../PROJECTS/0002-mac-mini-ai-office-setup.md)  
+> **Owner:** Human (`matt@appyhourlabs.com`)  
+> **Priority:** P0  
+> **Status:** Open  
+> **CampClaw Step:** 03 — The Mac Mini (final step)
+
+---
+
+## Goal
+
+Install OpenClaw on the Mac Mini under the `aioffice` user and connect it to the `#ai-office` Slack channel in the Appy Hour Labs workspace. This completes CampClaw Step 03.
+
+---
+
+## Pre-flight Checklist
+
+Before starting, confirm:
+- [ ] Logged in as `aioffice` macOS user
+- [ ] `#ai-office` Slack channel created in Appy Hour Labs workspace
+- [ ] Internet access confirmed
+
+---
+
+## Steps
+
+### 1 — Upgrade Node to 22+
+
+OpenClaw requires Node 22 or newer (we installed Node 20).
+
+> ⚠️ Do this as **admin**, then switch back to `aioffice`.
+
+```bash
+brew install node@22
+brew link node@22 --force --overwrite
+node --version   # must say v22.x.x
+```
+
+---
+
+### 2 — Install OpenClaw (as `aioffice`)
+
+```bash
+curl -fsSL https://openclaw.ai/install.sh | bash
+```
+
+Verify:
+```bash
+openclaw --version
+```
+
+---
+
+### 3 — Run the Onboarding Wizard
+
+```bash
+openclaw onboard --install-daemon
+```
+
+This will:
+- Configure auth (API key for your LLM — Anthropic or OpenAI)
+- Install the background daemon
+- Ask which channel to connect
+
+---
+
+### 4 — Create the Slack App
+
+> Do this in a browser (can use phone or switch to admin account)
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps)
+2. Click **Create New App → From scratch**
+3. Name: `AI Office` | Workspace: `Appy Hour Labs`
+4. Under **OAuth & Permissions**, add these Bot Token Scopes:
+   - `chat:write`
+   - `channels:read`
+   - `channels:history`
+   - `app_mentions:read`
+5. Click **Install to Workspace** → authorize
+6. Copy the **Bot User OAuth Token** (`xoxb-...`)
+7. Under **Basic Information**, copy the **Signing Secret**
+8. Under **Event Subscriptions**, enable events — add `app_mention` and `message.channels`
+
+---
+
+### 5 — Connect OpenClaw to Slack
+
+When the onboarding wizard prompts for a channel, select **Slack** and enter:
+- Bot token: `xoxb-...`
+- Signing secret: (from step 4)
+- Target channel: `#ai-office`
+
+Or configure manually:
+```bash
+openclaw channels add slack
+```
+
+---
+
+### 6 — Verify
+
+```bash
+openclaw gateway status
+```
+
+Send a test message to confirm the connection:
+```bash
+openclaw message send --target "#ai-office" --message "OpenClaw is online. AI Office ready."
+```
+
+Check `#ai-office` in Slack — the message should appear.
+
+---
+
+## Owner (Human vs AI)
+
+**Human only.** Requires physical presence at Mac Mini and Slack app creation.
+
+---
+
+## Dependencies
+
+- Task 0003 ✅ — `aioffice` user exists
+- Task 0004 ✅ — Homebrew, Node installed (Node 22 upgrade needed)
+- Task 0005 ✅ — Chrome profiles set up (useful for Slack App creation)
+- `#ai-office` Slack channel created ✅
+
+---
+
+## Definition of Done
+
+- [ ] Node 22+ confirmed (`node --version`)
+- [ ] OpenClaw installed (`openclaw --version`)
+- [ ] Onboarding wizard completed; daemon running
+- [ ] Slack App created with correct scopes
+- [ ] OpenClaw connected to `#ai-office` channel
+- [ ] Test message successfully received in `#ai-office`
+- [ ] `openclaw gateway status` shows healthy
+
+---
+
+## Risk Notes
+
+- **LLM API key required.** You'll need an Anthropic or OpenAI API key during onboarding. Have it ready — do not store it in this repo.
+- **Slack app needs to be invited to `#ai-office`:** After creating the bot, run `/invite @AI Office` in the channel.
+- **Node 22 upgrade:** `brew link --overwrite` is safe but confirm `node --version` returns 22.x before proceeding.

--- a/TASKS/0014-doc-agent-step04-configure.md
+++ b/TASKS/0014-doc-agent-step04-configure.md
@@ -1,0 +1,114 @@
+# Task 0014 — Configure Doc Agent in OpenClaw (CampClaw Step 04)
+
+> **Project:** AI Workforce Lab — Agent Operations  
+> **Owner:** Human (`matt@appyhourlabs.com`) setup; AI (`doc@appyhourlabs.com`) operation  
+> **Priority:** P1  
+> **Status:** Open  
+> **CampClaw Step:** 04 — The Build  
+> **Depends on:** Task 0013 (OpenClaw installed and connected to Slack)
+
+---
+
+## Goal
+
+Configure the Documentary Agent (`doc@appyhourlabs.com`) as the first live agent in OpenClaw. This agent reads project updates from the repo and drafts public-friendly episode logs. Starting with `doc` gives the lowest-risk first deployment — it only reads files and outputs drafts for human review.
+
+---
+
+## Why Doc Agent First
+
+- **Lowest blast radius:** reads files, writes drafts — no external API calls, no emails sent
+- **Immediately valuable:** documents the OpenClaw setup itself as it happens
+- **Self-referential loop:** the first thing the agent documents is its own creation
+- **Tests the full Step 04–05 pipeline** without touching live external systems
+
+---
+
+## Steps
+
+### 1 — Configure Agent Identity in OpenClaw
+
+In the OpenClaw dashboard (`openclaw dashboard`), create a new agent:
+
+- **Name:** `Documentary Agent`
+- **Identity / Account:** `doc@appyhourlabs.com`
+- **Channel:** Slack → `#ai-office`
+
+---
+
+### 2 — Set the System Prompt
+
+Use the contents of [`AGENTS/documentary-agent.md`](../AGENTS/documentary-agent.md) as the system prompt. Paste the full file contents into OpenClaw's system prompt / behavior instructions field.
+
+Key sections to include:
+- Mission
+- Inputs (project files, policies, runbooks)
+- Responsibilities
+- Safety constraints (no secrets, no unapproved publishing)
+- Output style
+
+---
+
+### 3 — Configure File Access
+
+Grant the agent read access to these repo paths:
+- `PROJECTS/` — for project status updates
+- `TASKS/` — for task completion context
+- `POLICIES/` — for safety boundaries
+- `RUNBOOKS/session-handoff.md` — for operational context
+- `DOCS/SHOW/episodes/` — for episode drafts output
+
+Write access:
+- `DOCS/SHOW/episodes/` — drafts only; never directly to `main`
+
+---
+
+### 4 — First Task: Draft Episode 002
+
+Trigger the agent with this prompt in `#ai-office`:
+
+> "Draft Episode 002: 'The First Agent Goes Live'. Cover: OpenClaw install on the Mac Mini, the decision to start with the Documentary Agent, and what Phase A gated operation means in practice. Follow the episode template. Flag anything uncertain for human review."
+
+---
+
+### 5 — Review and Merge
+
+1. Agent posts draft to `#ai-office` or creates file in `DOCS/SHOW/episodes/002-*.md`
+2. Run through [`EVALS/outbound-quality-gate.md`](../EVALS/outbound-quality-gate.md)
+3. Run through [`EVALS/brand-voice-gate.md`](../EVALS/brand-voice-gate.md)
+4. Submit PR; `matt@appyhourlabs.com` approves and merges
+
+---
+
+## Owner (Human vs AI)
+
+- **OpenClaw configuration:** Human (`matt@appyhourlabs.com`)
+- **Episode drafting:** AI (`doc@appyhourlabs.com`)
+- **Quality gates + merge:** Human (`matt@appyhourlabs.com`)
+
+---
+
+## Dependencies
+
+- Task 0013 ✅ required — OpenClaw installed and connected to Slack
+- [`AGENTS/documentary-agent.md`](../AGENTS/documentary-agent.md) — system prompt source
+- [`DOCS/SHOW/episodes/_TEMPLATE.md`](../DOCS/SHOW/episodes/_TEMPLATE.md) — episode structure
+
+---
+
+## Definition of Done
+
+- [ ] Documentary Agent configured in OpenClaw with correct system prompt
+- [ ] File access paths configured (read: PROJECTS, TASKS, POLICIES; write: DOCS/SHOW/episodes)
+- [ ] First prompt issued in `#ai-office`
+- [ ] Episode 002 draft produced by agent
+- [ ] Both quality gates passed
+- [ ] PR reviewed and merged by `matt@appyhourlabs.com`
+
+---
+
+## Risk Notes
+
+- **Agent must not publish directly** — all output goes to `DOCS/SHOW/episodes/` as drafts and requires human PR approval before merge.
+- **System prompt is the contract.** If the agent drifts from the safety constraints, update `AGENTS/documentary-agent.md` and re-paste into OpenClaw.
+- **No credentials in drafts.** The safety constraint in the agent definition is enforced at the system prompt level — review every draft for accidental info leakage before merging.


### PR DESCRIPTION
## Summary

Closes out CampClaw Step 03 infrastructure work and lays the runway for Step 04.

### Step 03 — All Done ✅
- Tasks 0003–0006 all marked Done (aioffice user, hardening, toolchain, Chrome profiles, logging)
- `ai-office-logs/` added to `.gitignore`

### New Tasks
- **TASKS/0013** — OpenClaw install + Slack connect (Step 03 final step)
  - Node 22 upgrade, install script, onboarding wizard, Slack App setup
  - Connects to `#ai-office` channel
- **TASKS/0014** — Configure doc agent in OpenClaw (Step 04 - The Build)
  - First agent: `doc@appyhourlabs.com` (lowest blast radius, self-documenting)
  - System prompt sourced from `AGENTS/documentary-agent.md`
  - First task: draft Episode 002 — 'The First Agent Goes Live'

### Doc Updates
- `CAMPCLAW.md` — Step 03 all green, Step 04 section with task table
- `PROJECTS/0002` — Task 0013 added to project index