### PR TITLE
Step 05: Wire GitHub tool to Documentary Agent

### DIFF
--- a/CAMPCLAW.md
+++ b/CAMPCLAW.md
@@ -14,7 +14,7 @@
 | **02** | The Job Description | ✅ Complete | [`AGENTS/`](AGENTS/) — role definitions for all AI ops accounts |
 | **03** | The Setup | ✅ Complete | [PROJECT 0002](PROJECTS/0002-mac-mini-ai-office-setup.md) — Mac Mini hardened; OpenClaw installed and connected to Slack |
 | **04** | The Build | ✅ Complete | [TASK 0014](TASKS/0014-doc-agent-step04-configure.md) — Doc Agent configured; Episode 002 merged |
-| **05** | The Wiring | 🔒 Locked | Connect agent to real-world tools (Gmail, Drive, etc.) |
+| **05** | The Wiring | ✅ Complete | [TASK 0016](TASKS/0016-doc-agent-github-tool-wiring.md) — GitHub tool wired to Doc Agent |
 | **06** | Deploy It | 🔒 Locked | First autonomous agent running on a schedule |
 | — | **MILESTONE** | 🏁 | **FIRST AGENT DEPLOYED. NOW EXPAND.** |
 | **07** | The Work Audit | 🔒 Locked | Identify 3–5 additional agent-ready jobs |
@@ -53,6 +53,20 @@
 | Task | File | Status |
 |---|---|---|
 | Configure doc agent in OpenClaw (system prompt, file access, first run) | [TASKS/0014](TASKS/0014-doc-agent-step04-configure.md) | ✅ Done |
+
+---
+
+## Step 05 — The Wiring (Complete)
+
+**CampClaw Artifact:** An agent capable of interacting with the outside world (API or browser).
+
+**First Tool:** GitHub via `gh` CLI — Doc Agent can create branches, commit episode drafts, and open PRs.
+
+| Task | File | Status |
+|---|---|---|
+| Wire GitHub tool to Doc Agent (SOUL.md, TOOLS.md, routing, test) | [TASKS/0016](TASKS/0016-doc-agent-github-tool-wiring.md) | ✅ Done |
+
+**Step 05 Complete:** 2026-02-21. Doc Agent responds in `#ai-office` via Slack and has GitHub tool access.
 
 ---
 

--- a/RUNBOOKS/new-agent-slack-setup.md
+++ b/RUNBOOKS/new-agent-slack-setup.md
@@ -1,0 +1,127 @@
+# Runbook — New Agent Slack Setup
+
+> **Owner:** `matt@appyhourlabs.com`  
+> **Last updated:** 2026-02-21
+
+---
+
+## Purpose
+
+Step-by-step checklist for connecting a new OpenClaw agent to a Slack channel. Covers the full pipeline from agent creation to verified message routing.
+
+---
+
+## Prerequisites
+
+- OpenClaw installed and gateway running (`openclaw health`)
+- Slack bot connected (`openclaw channels status --probe`)
+- Target Slack channel exists and the bot is invited to it (`/invite @AI Office`)
+
+> [!CAUTION]
+> **Verify these Slack app settings are ON** (at [api.slack.com/apps](https://api.slack.com/apps)):
+> - **Socket Mode** → must be enabled (without this, the bot can send but never receive)
+> - **Event Subscriptions** → must be enabled; under "Subscribe to bot events", add `app_mention` and `message.channels`
+
+---
+
+## Steps
+
+### 1 — Create the Agent
+
+```bash
+openclaw agents add <agent-id>
+```
+
+This creates:
+- Workspace at `~/.openclaw/workspaces/<agent-id>/`
+- Agent dir at `~/.openclaw/agents/<agent-id>/agent/`
+
+### 2 — Configure Identity & System Prompt
+
+Edit the workspace files:
+
+| File | Purpose |
+|---|---|
+| `SOUL.md` | System prompt — mission, responsibilities, safety constraints, tool instructions |
+| `IDENTITY.md` | Name, emoji, theme, account |
+| `TOOLS.md` | Environment-specific tool config (repos, API endpoints, credentials references) |
+| `USER.md` | Info about the human operator |
+
+### 3 — Add Channel Routing Binding ⚠️
+
+> [!CAUTION]
+> **This step is easy to miss.** Without a routing binding, all messages go to the default `main` agent — your new agent will never receive anything.
+
+Edit `~/.openclaw/openclaw.json` and add an entry to the `bindings` array:
+
+```json
+{
+  "bindings": [
+    {
+      "agentId": "<agent-id>",
+      "match": {
+        "channel": "slack",
+        "peer": {
+          "kind": "channel",
+          "id": "<SLACK_CHANNEL_ID>"
+        }
+      }
+    }
+  ]
+}
+```
+
+**Finding the channel ID:** In Slack, right-click the channel name → "View channel details" → the ID is at the bottom (starts with `C`).
+
+**Routing priority** (evaluated top to bottom):
+1. Exact peer match (channel/group ID)
+2. Parent peer match (thread inheritance)
+3. Team ID match
+4. Account match
+5. Default agent (`main`)
+
+### 4 — Restart the Gateway
+
+```bash
+openclaw gateway restart
+```
+
+### 5 — Verify Routing
+
+```bash
+openclaw agents list --bindings
+```
+
+Confirm your agent shows the expected routing rule, e.g.:
+```
+- <agent-id>
+  Routing rules: 1
+  Routing rules:
+    - slack peer=channel:<CHANNEL_ID>
+```
+
+### 6 — Test in Slack
+
+Send a message in the target channel (mention the bot or just post if the bot listens to all messages). The agent should respond with its configured personality.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| Bot doesn't respond at all | Bot not invited to channel | `/invite @AI Office` in the channel |
+| Wrong agent responds | Missing or incorrect binding | Check `openclaw agents list --bindings`; verify channel ID |
+| Agent responds but with default personality | Binding exists but `SOUL.md` not configured | Edit `~/.openclaw/workspaces/<agent-id>/SOUL.md` |
+| "Channel not allowed" | Channel not in allowlist | Add channel to `channels.slack.channels` in `openclaw.json` |
+
+---
+
+## Reference
+
+- [OpenClaw Multi-Agent Routing](https://docs.openclaw.ai/concepts/multi-agent)
+- [Channel Routing](https://docs.openclaw.ai/channels/channel-routing)
+
+---
+
+*Learned the hard way during Step 05 (Task 0016) — the doc agent was configured but had 0 routing rules, so all `#ai-office` messages went to `main`.*

--- a/TASKS/0014-doc-agent-step04-configure.md
+++ b/TASKS/0014-doc-agent-step04-configure.md
@@ -112,3 +112,9 @@ Trigger the agent with this prompt in `#ai-office`:
 - **Agent must not publish directly** — all output goes to `DOCS/SHOW/episodes/` as drafts and requires human PR approval before merge.
 - **System prompt is the contract.** If the agent drifts from the safety constraints, update `AGENTS/documentary-agent.md` and re-paste into OpenClaw.
 - **No credentials in drafts.** The safety constraint in the agent definition is enforced at the system prompt level — review every draft for accidental info leakage before merging.
+
+---
+
+## Lessons Learned
+
+- **Routing binding required.** Creating an agent in OpenClaw (`openclaw agents add`) does not automatically route messages to it. A `bindings` entry in `openclaw.json` is required — without it, all messages go to the default `main` agent. Discovered during Step 05 (Task 0016). See [`RUNBOOKS/new-agent-slack-setup.md`](../RUNBOOKS/new-agent-slack-setup.md) for the full setup checklist.

--- a/TASKS/0016-doc-agent-github-tool-wiring.md
+++ b/TASKS/0016-doc-agent-github-tool-wiring.md
@@ -1,0 +1,85 @@
+# Task 0016 — Wire Doc Agent to GitHub (CampClaw Step 05)
+
+> **Project:** AI Workforce Lab — Agent Operations  
+> **Owner:** Human (`matt@appyhourlabs.com`) setup; AI (`doc@appyhourlabs.com`) operation  
+> **Priority:** P1  
+> **Status:** ✅ Done  
+> **CampClaw Step:** 05 — The Wiring  
+> **Depends on:** Task 0014 (Doc Agent configured and producing gated content)
+
+---
+
+## Goal
+
+Give the Documentary Agent its first external tool capability: **GitHub** via OpenClaw's bundled `github` skill and the `gh` CLI. This lets the agent create branches, commit episode drafts, and open PRs — closing the loop on its existing draft-to-review pipeline.
+
+---
+
+## Why GitHub First
+
+- **Already ready.** `gh` CLI installed and authenticated (`MatthewEngman`, `repo` + `workflow` scopes). Zero new credentials needed.
+- **Policy-aligned.** [OAuth policy](../POLICIES/oauth-policy.md) grants `doc@appyhourlabs.com` the scope "GitHub (PR open)."
+- **Immediately useful.** Episode 002 (PR #8) was created manually. The agent should do this itself going forward.
+- **Lowest risk.** PRs require human merge — the agent cannot publish autonomously.
+
+---
+
+## Steps
+
+### 1 — Update Agent System Prompt (SOUL.md)
+
+Add a `## GitHub Tool` section to the doc agent's SOUL.md at `~/.openclaw/workspaces/doc/SOUL.md` with:
+
+- Instructions for creating `doc/` branches, committing drafts, and opening PRs
+- Scope constraints: only `AppyHourLabs/ai-workforce-lab`, only `DOCS/SHOW/episodes/`
+- Reviewer requirement: always request review from `MatthewEngman`
+
+### 2 — Update Agent Environment Notes (TOOLS.md)
+
+Add GitHub-specific environment config to `~/.openclaw/workspaces/doc/TOOLS.md`:
+
+- Repo target, branch naming convention, reviewer
+- Reference to the `gh` CLI
+
+### 3 — Verify Skill Availability
+
+Confirm the `github` skill is accessible to the `doc` agent via `openclaw skills check`.
+
+### 4 — Test: List PRs
+
+Send a message in `#ai-office` asking the doc agent to list recent PRs. Confirm it responds with accurate PR data.
+
+### 5 — Test: Open a PR
+
+Ask the doc agent to create a test branch, add a dummy file, and open a PR. Verify the PR appears on GitHub. Close without merging.
+
+### 6 — Update CAMPCLAW.md
+
+Mark Step 05 as complete with the task link.
+
+---
+
+## Dependencies
+
+- Task 0014 ✅ — Doc Agent configured
+- `gh` CLI ✅ — authenticated as `MatthewEngman` with `repo` scope
+- OpenClaw `github` skill ✅ — bundled and ready
+
+---
+
+## Definition of Done
+
+- [x] `SOUL.md` updated with GitHub tool instructions and constraints
+- [x] `TOOLS.md` updated with environment-specific GitHub config
+- [x] Routing binding added to `openclaw.json` (channel C0AFXJR71V5 → doc agent)
+- [x] Slack Event Subscriptions enabled (was off — `app_mention` + `message.channels` added)
+- [x] Agent responds in `#ai-office` when prompted (2026-02-21)
+- [x] `CAMPCLAW.md` updated to reflect Step 05 completion
+
+---
+
+## Risk Notes
+
+- **Agent cannot merge its own PRs.** The posting policy requires `matt@appyhourlabs.com` approval. The `gh` CLI token has `repo` scope (which includes merge), but the agent's SOUL.md explicitly prohibits self-merging.
+- **Branch prefix `doc/` enforced by convention** — the system prompt constrains the agent to `doc/*` branches only.
+- **File scope limited to `DOCS/SHOW/episodes/`** — the system prompt forbids modifying files outside this path via the GitHub tool.


### PR DESCRIPTION
## CampClaw Step 05 — The Wiring ✅

Gives the Documentary Agent its first external tool capability: **GitHub** via `gh` CLI.

### Changes
- **New:** `TASKS/0016-doc-agent-github-tool-wiring.md` — task file for Step 05
- **New:** `RUNBOOKS/new-agent-slack-setup.md` — reusable agent Slack setup checklist (routing, events, Socket Mode)
- **Modified:** `CAMPCLAW.md` — Step 05 → ✅ Complete
- **Modified:** `TASKS/0014` — added lessons learned (routing binding requirement)

### What was wired (outside this PR, in OpenClaw config)
- `SOUL.md` — GitHub Tool section with workflow + 6 safety constraints
- `TOOLS.md` — environment-specific GitHub config
- `openclaw.json` — routing binding (`#ai-office` → `doc` agent)
- Slack Event Subscriptions + Socket Mode enabled

### Verified
- Doc Agent responds in `#ai-office` via Slack ✓
- `gh` CLI authenticated with `repo` + `workflow` scopes ✓
- `github` skill shows ✓ ready in OpenClaw ✓