### PR TITLE
docs: update README and CAMPCLAW for 8-agent fleet

### DIFF
--- a/CAMPCLAW.md
+++ b/CAMPCLAW.md
@@ -1,7 +1,7 @@
 # CampClaw Path — AI Workforce Lab
 
 > **Program:** [Claw Camp](https://campclaw.ai/my-path) · "Thirteen projects from security briefing to agent team. Each one ends with something real."
-> **Account:** AppyhourLabs · *Last synced: 2026-02-21*
+> **Account:** AppyhourLabs · *Last synced: 2026-02-22*
 
 ---
 
@@ -21,6 +21,7 @@
 | **08** | The Second Agent | ✅ Complete | QA, Content, and Security agents deployed |
 | **09** | The Shared Brain | ✅ Complete | [TASK 0020](TASKS/0020-step09-shared-brain.md) — Shared memory layer wired across fleet |
 | **10** | The Manager | ✅ Complete | [TASK 0021](TASKS/0021-step10-manager-agent.md) — Manager agent delegates to specialists |
+| — | **Fleet Expansion** | ✅ Complete | TASKs [0022](TASKS/0022-cfo-agent-setup.md), [0023](TASKS/0023-cto-agent-setup.md), [0024](TASKS/0024-sdr-agent-setup.md) — CFO, CTO, SDR onboarded |
 | **11** | The System | 🔒 Locked | Full operation documented — monitoring & management |
 | **12** | The Playbook | 🔒 Locked | Personalized AI workforce playbook |
 
@@ -160,6 +161,9 @@ See [TASK 0018](TASKS/0018-step07-work-audit.md) for full scoring and rationale.
 | 04:30 ET | 🔍 QA | Quality + brand voice gates |
 | 05:00 ET | ✍️ Content | Social/blog drafts |
 | 05:30 ET | 🛡️ Security | PR security scans |
+| 06:00 ET | 💰 CFO | Budget/cost/token efficiency |
+| 06:30 ET | 🏗️ CTO | Architecture/SDLC review |
+| 07:00 ET | 📞 SDR | Prospect/outreach check |
 
 **Step 10 Complete:** 2026-02-22. Manager agent deployed.
 
@@ -180,7 +184,7 @@ Weekly check-ins at [campclaw.ai/check-in](https://campclaw.ai/check-in).
 
 | Question | This Week's Answer |
 |---|---|
-| What did you build? | Steps 00–10 complete. 5 agents deployed (doc, QA, content, security, manager) on staggered daily crons (03:45–05:30 ET). Shared brain wired — agents share context via handoff notes. Manager agent orchestrates fleet. Morning pipeline verified working. |
+| What did you build? | Steps 00–10 complete. 8 agents deployed (manager, doc, QA, content, security, CFO, CTO, SDR) on staggered daily crons (03:45–07:00 ET). Shared brain wired — agents share context via handoff notes. Manager agent orchestrates fleet. Gateway watchdog cron monitors health every 10 min. |
 | Are you blocked? | X API developer setup needed for automated social posting (deferred). |
 | Goal for next week? | Step 11 (The System) + Step 12 (The Playbook). Social posting deferred. |
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ That's what this repository answers. In real time. With the receipts committed.
 
 **EvalPal** is the product: tooling and methodology for evaluating AI agent quality in production workflows. The AI Workforce Lab is EvalPal's first test environment — we're building the eval harness by being the thing it evaluates.
 
-**The experiment:** deploy AI agents into operational roles (documentation, sales research, content, financial analysis, technical strategy) using a tiered autonomy model. Document everything. Ship the governance alongside the features.
+**The experiment:** deploy AI agents into operational roles (documentation, QA, content, security, financial analysis, technical strategy, sales outreach) using a tiered autonomy model. Document everything. Ship the governance alongside the features.
+
+**Current fleet:** 8 agents running on staggered daily cron schedules (03:45–07:00 ET), coordinated by a manager agent with shared brain memory.
 
 **The constraint:** safety first. Always. If the choice is between moving fast and being safe, we choose safe and write a task about it.
 
@@ -59,16 +61,27 @@ ai-workforce-lab/
 
 ## The Team
 
-| Account | Type | Role |
-|---|---|---|
-| `matt@appyhourlabs.com` | 👤 Human | Founder — final authority on all policy and autonomy decisions |
-| `ai@appyhourlabs.com` | 🤖 AI Ops | General operations, technical and research tasks |
-| `doc@appyhourlabs.com` | 🤖 AI Ops | Documentary agent — writes the weekly show |
-| `sales@appyhourlabs.com` | 🤖 AI Ops | Outreach research and drafting — Phase A gated |
-| `media@appyhourlabs.com` | 🤖 AI Ops | Content and distribution — Phase A gated |
-| `legal@appyhourlabs.com` | 👤 Human only | Legal review — no AI delegation |
-| `security@appyhourlabs.com` | 👤 Human only | Credential and security management — human only |
-| `billing@appyhourlabs.com` | 👤 Human only | Financial accounts — human only, no exceptions |
+### Human Operators
+
+| Account | Role |
+|---|---|
+| `matt@appyhourlabs.com` | Founder — final authority on all policy and autonomy decisions |
+| `legal@appyhourlabs.com` | Legal review — no AI delegation |
+| `security@appyhourlabs.com` | Credential and security management — human only |
+| `billing@appyhourlabs.com` | Financial accounts — human only, no exceptions |
+
+### AI Agent Fleet
+
+| Agent | ID | Schedule | Role |
+|---|---|---|---|
+| 🎯 Manager | `manager` | 03:45 ET | Fleet coordination, task routing, daily briefings |
+| 🎬 Documentary | `doc` | 04:00 ET | Episode drafting, repo scanning, PR creation |
+| 🔍 QA | `qa` | 04:30 ET | Quality gates, brand voice evaluation, PR review |
+| ✍️ Content | `content` | 05:00 ET | Social posts, blog drafts, content calendar |
+| 🛡️ Security | `security` | 05:30 ET | Security scans, policy checks, credential detection |
+| 💰 CFO | `cfo` | 06:00 ET | Budget modeling, cost tracking, token efficiency |
+| 🏗️ CTO | `cto` | 06:30 ET | ADRs, architecture, SDLC standards, CI/CD oversight |
+| 📞 SDR | `sdr` | 07:00 ET | Prospect research, outreach drafting, pipeline tracking |
 
 Full role specs: [`AGENTS/`](AGENTS/)
 
@@ -80,13 +93,15 @@ Every week, `doc@appyhourlabs.com` files an episode documenting what shipped, wh
 
 - [Episode 000 — Origin Log](DOCS/SHOW/episodes/000-origin-log.md)
 - [Episode 001 — The AI Office Moves In](DOCS/SHOW/episodes/001-ai-office-moves-in.md)
+- [Episode 002 — The First Agent Goes Live](DOCS/SHOW/episodes/002-the-first-agent-goes-live.md)
+- [Episode 003 — Agent Wires Itself](DOCS/SHOW/episodes/003-agent-wires-itself.md)
 - [Episode template](<DOCS/SHOW/episodes/_TEMPLATE.md>)
 
 ---
 
 ## Status
 
-*Last updated: 2026-02-21*
+*Last updated: 2026-02-22*
 
 | Project | Status | What it is |
 |---|---|---|
@@ -94,6 +109,8 @@ Every week, `doc@appyhourlabs.com` files an episode documenting what shipped, wh
 | [0002 — Mac Mini AI Office Setup](PROJECTS/0002-mac-mini-ai-office-setup.md) | 🔵 Active | Dedicated hardened machine for running agent pipelines |
 
 Autonomy tier: **Phase A** — all outbound requires human approval.
+
+Fleet: **8 agents** across 5 functions (documentation, quality, content, finance, engineering, sales). CampClaw Steps 00–10 complete. Steps 11–12 in progress.
 
 ---
 


### PR DESCRIPTION
Updates repo documentation to reflect the expanded fleet after onboarding CFO, CTO, and SDR agents.

## Changes

- **README.md**: Expanded team table showing all 8 agents with IDs and schedules. Updated status section with fleet count and current date.
- **CAMPCLAW.md**: Extended morning pipeline table (03:45–07:00 ET). Added fleet expansion row in progress overview. Updated check-in to reflect 8 agents and watchdog.

## Security Considerations

No secrets, credentials, or PII. Documentation-only change.