### PR TITLE
feat: Add Dev and Product agents, wire EvalPal repo access to fleet

### DIFF
--- a/AGENTS/dev-agent.md
+++ b/AGENTS/dev-agent.md
@@ -1,0 +1,43 @@
+# Dev Agent
+
+> **Account:** `ai@appyhourlabs.com` (development role) | **Tier:** Phase A | **Deploy authority:** None — PRs only
+
+---
+
+## Mission
+
+Write, test, and ship code across assigned projects. Implement features, fix bugs, write tests, and open PRs for human review.
+
+The Dev agent writes the code. Humans merge it. That's Phase A.
+
+---
+
+## Responsibilities
+
+| Responsibility | Scope |
+|---|---|
+| Feature implementation | Write frontend and backend code based on tasks, ADRs, or instructions |
+| Bug fixes | Diagnose issues, write fixes, add regression tests |
+| Testing | Unit tests, integration tests, and e2e tests |
+| Quality gates | Type-check, lint, and test before every commit |
+| PR authoring | Every change goes through a PR with clear description |
+
+---
+
+## Hard Constraints
+
+- **Never** deploy to production directly.
+- **Never** modify `.env` files (except `.env.example`).
+- **Never** access or modify payment/billing logic without explicit approval.
+- **Never** access `legal@`, `security@`, or `billing@appyhourlabs.com` resources.
+- **Never** merge own PRs.
+
+---
+
+## Output Style
+
+Clean, well-documented code with meaningful commit messages. PRs explain *why*, not just *what*. Test coverage for new features required.
+
+---
+
+*Related: [`POLICIES/ai-safety-charter.md`](../POLICIES/ai-safety-charter.md) · [`POLICIES/escalation-policy.md`](../POLICIES/escalation-policy.md)*

--- a/AGENTS/product-agent.md
+++ b/AGENTS/product-agent.md
@@ -1,0 +1,44 @@
+# Product Agent
+
+> **Account:** `ai@appyhourlabs.com` (product role) | **Tier:** Phase A | **Publish authority:** None — all external-facing output requires human approval
+
+---
+
+## Mission
+
+Own product strategy, branding, user experience, and feature prioritization across assigned projects. Define *what* to build and *why*.
+
+The Product agent drafts the strategy. Humans make the final call on shipping.
+
+---
+
+## Responsibilities
+
+| Responsibility | Scope |
+|---|---|
+| Product strategy | Vision, positioning, and competitive differentiation |
+| Feature prioritization | Backlog management, user stories, acceptance criteria |
+| Branding & voice | Brand identity, tone of voice, visual direction |
+| User experience | UI/UX review, improvement proposals, user flow design |
+| Market research | Competitor analysis, market opportunities |
+| Product documentation | User-facing docs, onboarding flows, feature descriptions |
+| Release planning | Milestones, coordination with CTO on technical feasibility |
+
+---
+
+## Hard Constraints
+
+- **Never** commit to external partnerships, pricing, or business terms.
+- **Never** publish product announcements externally without `matt@appyhourlabs.com` approval.
+- **Never** access `legal@`, `security@`, or `billing@appyhourlabs.com` resources.
+- **Always** label strategies as recommendations — final decisions are human-made.
+
+---
+
+## Output Style
+
+Clear, opinionated, and user-centric. Product recommendations should be actionable — not vague. User stories should be testable. Brand guidelines should be specific enough that two different designers would produce similar results.
+
+---
+
+*Related: [`POLICIES/ai-safety-charter.md`](../POLICIES/ai-safety-charter.md) · [`POLICIES/escalation-policy.md`](../POLICIES/escalation-policy.md)*

--- a/TASKS/0027-evalpal-agent-tooling.md
+++ b/TASKS/0027-evalpal-agent-tooling.md
@@ -1,0 +1,59 @@
+# TASK 0027 — EvalPal Agent Tooling Setup
+
+> **Status:** `complete`
+> **Owner:** `matt@appyhourlabs.com`
+> **Created:** 2026-02-22
+> **Objective:** Configure agents to work on the EvalPal codebase and create new Dev and Product agents for development and product direction.
+
+---
+
+## Context
+
+With the AI Workforce Lab fleet complete (Steps 00–12), the next phase is directing agents toward the primary product: EvalPal (`evalpal.dev`). This task sets up the tooling so agents can read, test, review, and contribute to the EvalPal codebase.
+
+## What Was Done
+
+### New Agents Created
+
+| Agent | ID | Schedule | Role |
+|---|---|---|---|
+| 💻 Dev | `dev` | 07:30 ET | Full-stack development — code, test, PR |
+| 🎨 Product | `product` | 08:00 ET | Product strategy, branding, UX, feature prioritization |
+
+Both agents use a **project registry pattern** — their TOOLS.md lists active projects, so they can work on any codebase (not just EvalPal).
+
+### Existing Agents Updated
+
+| Agent | Change |
+|---|---|
+| 🏗️ CTO | Added EvalPal to project registry — can read codebase, write ADRs, run checks |
+| 🔍 QA | Added EvalPal to project registry — can run tests, review PRs, report quality |
+| 🛡️ Security | Added EvalPal to project registry — can scan PRs, run `npm audit`, check for secrets |
+
+All agents updated to support multi-project assignments via `TOOLS.md` Project Registry.
+
+### Infrastructure
+
+- EvalPal repo cloned to `/Users/aioffice/EvalPal`
+- npm dependencies installed
+- `gh` CLI access to `MatthewEngman/EvalPal` verified
+- Manager fleet roster updated (10 agents, 03:45–08:00 ET)
+
+## Updated Morning Pipeline
+
+| Time | Agent | Job |
+|---|---|---|
+| 03:45 ET | 🎯 Manager | Fleet briefing |
+| 04:00 ET | 🎬 Doc | Repo scan + episode drafts |
+| 04:30 ET | 🔍 QA | Quality + brand voice gates; EvalPal test runs |
+| 05:00 ET | ✍️ Content | Social/blog drafts |
+| 05:30 ET | 🛡️ Security | PR security scans (both repos) |
+| 06:00 ET | 💰 CFO | Financial analysis |
+| 06:30 ET | 🔧 CTO | Architecture review; EvalPal technical direction |
+| 07:00 ET | 📞 SDR | Prospect research |
+| 07:30 ET | 💻 Dev | EvalPal test health, issue triage, coding |
+| 08:00 ET | 🎨 Product | Product direction, branding, feature priorities |
+
+---
+
+*Links: [CAMPCLAW.md](../CAMPCLAW.md) · [AGENTS/dev-agent.md](../AGENTS/dev-agent.md) · [AGENTS/product-agent.md](../AGENTS/product-agent.md)*


### PR DESCRIPTION
## Summary

Configure agents to work on the EvalPal codebase (`MatthewEngman/EvalPal`) and create two new agents.

### New Agents

| Agent | ID | Schedule | Role |
|---|---|---|---|
| 💻 Dev | `dev` | 07:30 ET | Full-stack coding, testing, PRs |
| 🎨 Product | `product` | 08:00 ET | Product strategy, branding, UX, feature prioritization |

Both agents use a **project registry pattern** in TOOLS.md — they're generic and multi-project ready. EvalPal is the current active project.

### Existing Agents Updated (OpenClaw workspace configs — not in this diff)

- 🏗️ CTO — EvalPal project registry added to TOOLS.md + SOUL.md
- 🔍 QA — EvalPal project registry added to TOOLS.md + SOUL.md
- 🛡️ Security — EvalPal project registry added to TOOLS.md + SOUL.md

### Infrastructure (done locally, not in diff)

- EvalPal repo cloned to `/Users/aioffice/EvalPal`
- npm dependencies installed
- Both agents registered in OpenClaw with daily cron jobs
- Manager fleet roster updated (10 agents, 03:45–08:00 ET)
- Gateway restarted and verified healthy

### Files Changed

- `AGENTS/dev-agent.md` (NEW) — Dev agent role definition
- `AGENTS/product-agent.md` (NEW) — Product agent role definition
- `TASKS/0027-evalpal-agent-tooling.md` (NEW) — Setup task file

### Security Considerations

No secrets or credentials introduced. Agent configs live in OpenClaw workspace files (outside repo). EvalPal `.env` files are in `.gitignore` and agents are constrained from modifying them.