### PR TITLE
Eval: Episode 003 — quality FAIL (links)

### DIFF
--- a/EVALS/results/2026-02-22-episode-003-quality.md
+++ b/EVALS/results/2026-02-22-episode-003-quality.md
@@ -1,0 +1,39 @@
+# Outbound Quality Gate — Episode 003
+
+> **Content:** Episode 003: "Agent Wires Itself"
+> **Type:** Episode log (documentary)
+> **Date:** 2026-02-22
+> **Runner:** QA Agent (`ai@appyhourlabs.com`)
+
+---
+
+## Per-Criterion Scores
+
+| # | Criterion | Score | Notes |
+|---|---|---|---|
+| 1 | Factual accuracy | 2 | Shipping table items match repository history (Task 0014: PR #8 merged; Task 0016 file present). Metrics and incident counts align with current repo state. |
+| 2 | No PII | 2 | Only org emails (`doc@…`, `matt@…`). No personal data. |
+| 3 | No secrets | 2 | No tokens, credentials, or sensitive config. |
+| 4 | Scope compliance | 2 | Stays within AI Workforce Lab operations (doc agent setup, routing, cron design). |
+| 5 | Tone alignment | 2 | Dry, specific narration consistent with lab voice. |
+| 6 | Completeness | 2 | All template sections populated, including metrics, decisions, plan, and confessional. |
+| 7 | Link hygiene | 0 | References to `[TASKS/0014](../../TASKS/0014-doc-agent-step04-configure.md)`, `[TASKS/0016](../../TASKS/0016-doc-agent-github-tool-wiring.md)`, and `[RUNBOOKS/new-agent-slack-setup.md](../../RUNBOOKS/new-agent-slack-setup.md)` are broken. From `DOCS/SHOW/episodes/`, these paths resolve to `DOCS/TASKS` and `DOCS/RUNBOOKS`, which do not exist. Paths should step up three levels (e.g., `../../../TASKS/...`). |
+| 8 | Policy compliance | 2 | No policy violations detected. |
+
+---
+
+## Scoring
+
+```
+Total score: 14 / 16
+
+PASS threshold: ≥ 14
+Result: gate: FAIL (criterion #7 scored 0 — broken links)
+```
+
+---
+
+## Remediation Required
+
+1. Update all relative links from Episode 003 so they point to real files (e.g., `../../../TASKS/0014-doc-agent-step04-configure.md`, `../../../RUNBOOKS/new-agent-slack-setup.md`).
+2. Re-run the gate once links resolve correctly.

--- a/EVALS/results/2026-02-22-episode-003-voice.md
+++ b/EVALS/results/2026-02-22-episode-003-voice.md
@@ -1,0 +1,36 @@
+# Brand Voice Gate — Episode 003
+
+> **Content:** Episode 003: "Agent Wires Itself"
+> **Type:** Episode log (documentary)
+> **Date:** 2026-02-22
+> **Runner:** QA Agent (`ai@appyhourlabs.com`)
+
+---
+
+## Per-Criterion Scores
+
+| # | Criterion | Score | Notes |
+|---|---|---|---|
+| 1 | Honesty | 2 | Breakage section owns the Slack routing miss and quantifies the impact (`~30 min`, `2/10`). No spin. |
+| 2 | Tone | 2 | Dry, understated humor ("Guardrails held. Good guardrails." / "None. Suspicious.") with zero hype or exclamation points. |
+| 3 | Specificity | 2 | Names concrete tasks, timelines, owners, and success criteria. Metrics table includes precise counts and deltas. |
+| 4 | No AI-voice tells | 2 | No stock LLM phrases, no "In conclusion," no hollow affirmations. Confessional reads like a human aside. |
+| 5 | Accountability | 2 | Decisions and lessons call out who owns them and what slipped (cron wiring still pending). Responsibility is explicitly assigned. |
+
+---
+
+## Scoring
+
+```
+Total score: 10 / 10
+
+PASS threshold: ≥ 8
+Result: gate: PASS
+```
+
+---
+
+## Notes
+
+- Voice is consistent with previously published episodes; specificity plus mild wit keeps it on-brand.
+- Once link fixes are complete, the narrative is otherwise ready for the next review step (Phase A still requires human approval).


### PR DESCRIPTION
## Summary
- Outbound quality gate: **FAIL** (broken relative links to TASKS/0014, TASKS/0016, RUNBOOKS/new-agent-slack-setup)
- Brand voice gate: **PASS** (tone + specificity on target)

## Files
- Adds 2026-02-22 quality + voice gate reports under EVALS/results/

## Next Steps
- Fix relative links in Episode 003 so they resolve to real files (should step up three levels from DOCS/SHOW/episodes/)
- Re-run quality gate once fixed