### PR TITLE
fix: update fleet roster to 10 agents, fix Slack channel ID in all docs

### DIFF
--- a/DOCS/system-operations.md
+++ b/DOCS/system-operations.md
@@ -19,8 +19,10 @@ Complete operational reference for the AI Workforce Lab fleet. For step-by-step 
 | 6 | 💰 CFO | `cfo` | `ai@appyhourlabs.com` | 06:00 daily | Budget modeling, cost tracking, grant research | Zero financial authority — advisory only; no access to `billing@` |
 | 7 | 🔧 CTO | `cto` | `ai@appyhourlabs.com` | 06:30 daily | Architecture decisions, technical roadmap, CI/CD oversight | Does not merge, deploy, or provision infrastructure |
 | 8 | 📞 SDR | `sdr` | `sales@appyhourlabs.com` | 07:00 daily | Prospect research, outreach drafting, pipeline tracking | No autonomous email sends; all outbound human-gated |
+| 9 | 💻 Dev | `dev` | `ai@appyhourlabs.com` | 07:30 daily | Full-stack coding, testing, bug fixes, feature PRs | No deploys — PRs only, branch prefix `dev/` |
+| 10 | 🎨 Product | `product` | `ai@appyhourlabs.com` | 08:00 daily | Product strategy, branding, UX, feature prioritization | Advisory — no external announcements without approval |
 
-**Total fleet:** 8 agents · **Pipeline window:** 03:45–07:00 ET · **All agents:** Phase A
+**Total fleet:** 10 agents · **Pipeline window:** 03:45–08:00 ET · **All agents:** Phase A
 
 ---
 
@@ -44,11 +46,15 @@ The fleet runs on staggered daily crons. Each agent completes its work and write
 06:30  🔧 CTO         Architecture review and technical planning
         │
 07:00  📞 SDR         Prospect research and outreach drafting
+        │
+07:30  💻 Dev         Pull latest, run tests, check issues
+        │
+08:00  🎨 Product     Product health, branding review, feature priorities
 ```
 
-**Data flow:** Manager → Doc → QA → Content is a sequential pipeline. Security, CFO, CTO, and SDR run independently after the core pipeline.
+**Data flow:** Manager → Doc → QA → Content is a sequential pipeline. Security, CFO, CTO, SDR, Dev, and Product run independently after the core pipeline.
 
-**All output** is delivered to `#ai-office` via each agent's cron `delivery.to` config. Matt reviews during the morning.
+**All output** is delivered to `#ai-office` (channel ID `C0AFXJR71V5`) via each agent's cron `delivery.to` config. Matt reviews during the morning.
 
 ---
 
@@ -187,8 +193,9 @@ Hard-won lessons from building the fleet. Full details in [RUNBOOKS/new-agent-on
 |---|---|
 | **No specialist channel bindings** | Adding a channel binding for a specialist breaks routing — manager must be the sole `#ai-office` responder |
 | **@mention via autocomplete only** | Plain text `@manager` does not trigger the bot; you must use Slack's autocomplete to @mention the bot user |
-| **Channel ID format for CLI** | `openclaw agent --reply-to "#ai-office"` fails → use `--reply-to "channel:C0AFXJR71V5"` |
-| **Cron delivery ≠ binding** | Agents can *deliver* to `#ai-office` via cron's `delivery.to` without needing a channel binding |
+| **Channel ID required everywhere** | Both CLI (`--reply-to`) and cron (`delivery.to`) require Slack channel ID `C0AFXJR71V5`, not `#ai-office`. Display names fail silently |
+| **Cron delivery ≠ binding** | Agents can *deliver* to `#ai-office` (channel ID `C0AFXJR71V5`) via cron's `delivery.to` without needing a channel binding |
+| **Update SOUL.md + fleet-status.md** | When onboarding new agents, also update the manager's `SOUL.md` routing table and `fleet-status.md` — not just `TOOLS.md` |
 | **Non-interactive CLI only** | Commands like `gh pr create` (without `--fill`/`--body`) hang forever waiting for input |
 | **`missing_scope` warning is benign** | `channel resolve failed; using config entries` on startup is non-blocking — safe to ignore |
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ That's what this repository answers. In real time. With the receipts committed.
 
 **The experiment:** deploy AI agents into operational roles (documentation, QA, content, security, financial analysis, technical strategy, sales outreach) using a tiered autonomy model. Document everything. Ship the governance alongside the features.
 
-**Current fleet:** 8 agents running on staggered daily cron schedules (03:45–07:00 ET), coordinated by a manager agent with shared brain memory.
+**Current fleet:** 10 agents running on staggered daily cron schedules (03:45–08:00 ET), coordinated by a manager agent with shared brain memory.
 
 **The constraint:** safety first. Always. If the choice is between moving fast and being safe, we choose safe and write a task about it.
 
@@ -82,6 +82,8 @@ ai-workforce-lab/
 | 💰 CFO | `cfo` | 06:00 ET | Budget modeling, cost tracking, token efficiency |
 | 🏗️ CTO | `cto` | 06:30 ET | ADRs, architecture, SDLC standards, CI/CD oversight |
 | 📞 SDR | `sdr` | 07:00 ET | Prospect research, outreach drafting, pipeline tracking |
+| 💻 Dev | `dev` | 07:30 ET | Full-stack coding, testing, bug fixes, feature PRs |
+| 🎨 Product | `product` | 08:00 ET | Product strategy, branding, UX, feature prioritization |
 
 Full role specs: [`AGENTS/`](AGENTS/)
 
@@ -110,7 +112,7 @@ Every week, `doc@appyhourlabs.com` files an episode documenting what shipped, wh
 
 Autonomy tier: **Phase A** — all outbound requires human approval.
 
-Fleet: **8 agents** across 5 functions (documentation, quality, content, finance, engineering, sales). CampClaw Steps 00–10 complete. Steps 11–12 in progress.
+Fleet: **10 agents** across 7 functions (documentation, quality, content, security, finance, engineering, sales, product). CampClaw Steps 00–12 complete.
 
 ---
 

--- a/RUNBOOKS/cron-troubleshooting.md
+++ b/RUNBOOKS/cron-troubleshooting.md
@@ -37,10 +37,12 @@ cat /tmp/openclaw/openclaw-$(date +%Y-%m-%d).log | grep -i "error\|fail\|timeout
 
 **Fix:**
 ```bash
-openclaw cron edit <job-id> --announce --channel slack --to "#ai-office"
+openclaw cron edit <job-id> --announce --channel slack --to "C0AFXJR71V5"
 ```
 
-**Verify:** Check `~/.openclaw/cron/jobs.json` — each job's `delivery` block should have a `"to"` field.
+> ⚠️ **Use the Slack channel ID, not the display name.** `--to "#ai-office"` fails silently with `Slack channels require a channel id`. The `#ai-office` channel ID is `C0AFXJR71V5`.
+
+**Verify:** Check `~/.openclaw/cron/jobs.json` — each job's `delivery` block should have `"to": "C0AFXJR71V5"`.
 
 ---
 

--- a/RUNBOOKS/new-agent-onboarding.md
+++ b/RUNBOOKS/new-agent-onboarding.md
@@ -11,9 +11,9 @@ Lessons learned during Steps 09/10 (2026-02-22):
 
 2. **Slack requires @mention in channels.** Config `ackReactionScope: "group-mentions"` means the bot only responds when the **Slack bot user** is @mentioned (via Slack autocomplete), not from plain text like `@manager`.
 
-3. **CLI delivery needs channel ID format.** `openclaw agent --reply-to "#ai-office"` fails — use `--reply-to "channel:C0AFXJR71V5"` instead. Cron delivery with `#ai-office` works fine (resolved internally).
+3. **All Slack delivery needs channel ID.** Both CLI (`--reply-to`) and cron (`delivery.to`) require the Slack channel ID, not the display name. `"#ai-office"` fails silently — use `"C0AFXJR71V5"` instead. For CLI: `--reply-to "C0AFXJR71V5"`. For cron: `"to": "C0AFXJR71V5"` in `jobs.json`.
 
-4. **Cron delivery ≠ channel binding.** Agents can deliver to `#ai-office` via cron's `delivery.to` without needing channel bindings. Bindings are for **receiving** interactive messages.
+4. **Cron delivery ≠ channel binding.** Agents can deliver to `#ai-office` (channel ID `C0AFXJR71V5`) via cron's `delivery.to` without needing channel bindings. Bindings are for **receiving** interactive messages.
 
 ## Prerequisites
 
@@ -109,7 +109,7 @@ openclaw cron add \
   --tz "America/New_York" \
   --session isolated \
   --announce \
-  --to "#ai-office" \
+  --to "C0AFXJR71V5" \
   --best-effort-deliver \
   --message "<prompt with shared brain read/write steps>"
 ```
@@ -145,13 +145,23 @@ openclaw status
 openclaw agents list
 ```
 
-### 9. Verify
+### 9. Update Manager SOUL.md Routing Table
+
+Add the new agent to the routing table in `~/.openclaw/workspaces/manager/SOUL.md` so the manager knows how to route tasks to it.
+
+### 10. Update Fleet Status
+
+Add the new agent to `~/.openclaw/workspaces/shared/brain/fleet-status.md` in the Active Agents table.
+
+### 11. Verify
 
 - [ ] Agent appears in `openclaw agents list`
 - [ ] Agent has `memory/` directory
-- [ ] Slack binding is in `openclaw.json`
 - [ ] Cron job appears in `openclaw cron list` (if scheduled)
+- [ ] Cron delivery `"to"` uses channel ID `C0AFXJR71V5` (not `#ai-office`)
 - [ ] Agent is in manager's fleet roster (`TOOLS.md`)
+- [ ] Agent is in manager's routing table (`SOUL.md`)
+- [ ] Agent is in `fleet-status.md`
 - [ ] Shared brain section is in agent's `SOUL.md`
 - [ ] Gateway is healthy after restart
 

--- a/TASKS/0017-doc-agent-step06-deploy-it.md
+++ b/TASKS/0017-doc-agent-step06-deploy-it.md
@@ -24,7 +24,7 @@ This is the final step before the **"First Agent Deployed"** milestone.
 Create a daily cron job targeting the `doc` agent:
 - **Schedule:** Daily at 04:00 AM Eastern (`0 4 * * * America/New_York`)
 - **Message:** Fast daily check-in — scan for changes, draft if warranted, return 2-3 sentence summary
-- **Delivery:** Announce summary to Slack `#ai-office` (`--announce --channel slack --to "#ai-office"`)
+- **Delivery:** Announce summary to Slack `#ai-office` — use channel ID `C0AFXJR71V5` (not display name)
 - **Session:** Isolated (each run starts clean)
 - **Timeout:** 900 seconds (increased from default after model-inference timeout)
 
@@ -91,7 +91,7 @@ Three stacked issues prevented the first autonomous morning run from delivering 
 
 The `openclaw cron add` command created jobs with `"delivery": {"mode": "announce", "channel": "slack"}` but **no `"to"` field**. OpenClaw requires an explicit destination.
 
-**Fix:** `openclaw cron edit <job-id> --announce --channel slack --to "#ai-office"` on all 4 jobs.
+**Fix:** `openclaw cron edit <job-id> --announce --channel slack --to "C0AFXJR71V5"` on all 4 jobs. Note: must use channel ID, not `#ai-office` (display names fail silently).
 
 ### 2. Device pairing required
 


### PR DESCRIPTION
## Summary

Three issues found during fleet testing:

1. **Manager reported 5 agents instead of 10** — SOUL.md routing table and fleet-status.md were stale (never updated when CFO, CTO, SDR, Dev, Product were onboarded)
2. **Slack delivery silently failing** — all cron jobs used `#ai-office` (display name) instead of channel ID `C0AFXJR71V5`
3. **Docs had incorrect info** — runbooks said cron delivery with `#ai-office` works (it doesn't)

## Changes

- **README.md** — fleet 8→10, added Dev + Product
- **DOCS/system-operations.md** — fleet roster + pipeline extended to 08:00 ET, delivery gotchas corrected
- **RUNBOOKS/new-agent-onboarding.md** — channel ID gotcha fixed, added SOUL.md + fleet-status.md verification steps
- **RUNBOOKS/cron-troubleshooting.md** — fix command uses channel ID with warning
- **TASKS/0017** — fix commands corrected to use channel ID

## Security Considerations

No secrets or credentials involved. Changes are documentation-only.