### PR TITLE
chore: repo hardening — SECURITY.md + .gitignore expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,17 @@ htmlcov/
 
 # Environment files
 .env
+.env.*
+.env.local
+.env.production
+
+# Credentials and keys (never commit)
+*.secret
+*.credentials
+*.key
+*.pem
+*.p12
+*.pfx
 
 # macOS
 .DS_Store

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Email `security@appyhourlabs.com`. Do not open public issues for security findings.
+
+We will acknowledge receipt within 48 hours and provide an initial assessment within 5 business days.
+
+---
+
+## Scope
+
+This repository contains **documentation, governance policies, and CI workflows** for the AI Workforce Lab. It does not contain application code, credentials, or infrastructure configurations.
+
+### In-Scope
+
+- Secrets or PII accidentally committed to any file or git history
+- CI workflow vulnerabilities (e.g., injection via PR titles, unsafe action versions)
+- CODEOWNERS or branch protection bypass vectors
+- Exposed infrastructure identifiers that could enable unauthorized access
+
+### Out of Scope
+
+- Slack channel IDs (not exploitable without valid OAuth tokens)
+- Email addresses documented as role identifiers in `AGENTS.md` and `AGENTS/`
+- Content quality issues in documentary episodes or drafted posts
+
+---
+
+## Protections in Place
+
+| Layer | Protection |
+|---|---|
+| **Secret scanning** | GitHub-native secret scanning + push protection enabled |
+| **CI** | `no-secrets.yml` scans all PR diffs for API keys, tokens, PEM blocks |
+| **Branch protection** | `main` requires PR review, status checks, no force-push |
+| **CODEOWNERS** | All governance files require `@AppyHourLabs/founders` review |
+| **PR template** | Security Considerations section mandatory on every PR |
+
+---
+
+## Credential Rotation
+
+If a credential is exposed in this repository — even briefly, even in a force-pushed commit — it must be rotated immediately. Removing the file or line is **not sufficient**; git history is permanent.
+
+See [`RUNBOOKS/ci.md`](RUNBOOKS/ci.md) for the full secret pattern list.
+
+---
+
+*Maintained by `matt@appyhourlabs.com` · Last updated: 2026-02-22*


### PR DESCRIPTION
## Summary

Hardens the repo for public visibility before social media promotion.

- Adds `SECURITY.md` with vulnerability reporting process and scope
- Expands `.gitignore` to block `.env.*`, `*.secret`, `*.credentials`, `*.key`, `*.pem`, `*.p12`, `*.pfx`

**Companion API changes already applied (not in this PR):**
- GitHub secret scanning + push protection enabled
- Dependabot security updates enabled
- Branch protection on `main` (require PR, 1 review, status checks, no force-push)
- `delete_branch_on_merge` enabled
- Actions restricted to GitHub-owned + verified creators only

---

## Security Considerations

This PR improves security posture. No secrets, PII, or credentials introduced.

---

## Policy Links

- [POLICIES/ai-safety-charter.md](POLICIES/ai-safety-charter.md)
- [RUNBOOKS/ci.md](RUNBOOKS/ci.md)