### PR TITLE
feat: add content pipeline schema and update agent/policy docs

### DIFF
--- a/AGENTS/content-agent.md
+++ b/AGENTS/content-agent.md
@@ -27,10 +27,15 @@ Good content is clear, honest, occasionally funny, and never makes claims the pr
 ## Phase A Publication Flow
 
 ```
-content-agent drafts → brand voice gate → matt@appyhourlabs.com reviews → matt@appyhourlabs.com publishes
+content-agent drafts episode → brand voice gate → opens PR to MatthewEngman/AppyHourLabs
+        → CI passes (build + tests) → matt@appyhourlabs.com reviews + merges
+        → Vercel auto-deploys → post is live on appyhourlabs.com/the-show
 ```
 
-No content goes live without passing the brand voice gate and receiving explicit human approval. The content agent does not have publish credentials for any external platform.
+**The content agent may only edit one file in the site repo:** `src/data/episodes.ts`.
+All output must conform to `SCHEMAS/content-schema.json` before a PR is opened.
+
+No content goes live without passing the brand voice gate and receiving explicit human approval. The content agent does not have publish credentials for any external platform. Social/external distribution is Phase B only.
 
 ---
 

--- a/POLICIES/posting-policy.md
+++ b/POLICIES/posting-policy.md
@@ -32,14 +32,21 @@ Outbound quality gate → gate: PASS required
         ↓
 Brand voice gate → gate: PASS required
         ↓
+Schema validation against SCHEMAS/content-schema.json → gate: PASS required
+        ↓
 Publish preflight checklist completed (RUNBOOKS/publish-preflight.md)
         ↓
-matt@appyhourlabs.com reviews and approves
+matt@appyhourlabs.com reviews PR to MatthewEngman/AppyHourLabs
         ↓
-matt@appyhourlabs.com publishes (or explicitly delegates the send action)
+matt@appyhourlabs.com merges PR → Vercel auto-deploys → live on appyhourlabs.com/the-show
 ```
 
-**`doc@appyhourlabs.com` specifically:** may open a PR with episode content after both gates pass. The PR merge by `matt@appyhourlabs.com` constitutes publication approval.
+**Phase A approved publish targets:**
+- `appyhourlabs.com/the-show` — site only, via PR merge
+
+**Phase B (not yet active):** External platforms (LinkedIn, X/Twitter, newsletter). See [`POLICIES/phase-a-to-b.md`](./phase-a-to-b.md) for promotion criteria.
+
+**`doc@appyhourlabs.com` specifically:** may open a PR with episode content after all gates pass. The PR merge by `matt@appyhourlabs.com` constitutes publication approval.
 
 ---
 

--- a/SCHEMAS/content-schema.json
+++ b/SCHEMAS/content-schema.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/AppyHourLabs/ai-workforce-lab/blob/main/SCHEMAS/content-schema.json",
+    "title": "Episode",
+    "description": "Schema for a single episode post as published to the AppyHourLabs.com Show page. The content-agent must validate output against this schema before opening a PR to the site repo.",
+    "type": "object",
+    "required": [
+        "id",
+        "title",
+        "date",
+        "tags",
+        "summary"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "id": {
+            "type": "string",
+            "description": "Unique episode identifier. kebab-case, e.g. 'episode-003'.",
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "title": {
+            "type": "string",
+            "description": "Human-readable episode title.",
+            "minLength": 5,
+            "maxLength": 120
+        },
+        "date": {
+            "type": "string",
+            "description": "ISO 8601 date string (YYYY-MM-DD).",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        },
+        "tags": {
+            "type": "array",
+            "description": "Topic tags. At least one required. No personal data.",
+            "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 40
+            },
+            "minItems": 1,
+            "maxItems": 10,
+            "uniqueItems": true
+        },
+        "summary": {
+            "type": "string",
+            "description": "2–4 sentence public excerpt. Must pass outbound-quality-gate and brand-voice-gate before PR is opened.",
+            "minLength": 50,
+            "maxLength": 500
+        },
+        "body": {
+            "type": "string",
+            "description": "Optional: full markdown body for expanded view. Same policy gates apply.",
+            "maxLength": 10000
+        },
+        "episodeUrl": {
+            "type": "string",
+            "description": "Optional: URL to the episode log or relevant file in the ai-workforce-lab repo.",
+            "format": "uri",
+            "pattern": "^https://github\\.com/AppyHourLabs/"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

What changed and why? Be specific. Link the task or project this closes:
- Closes: [TASKS/XXXX](../TASKS/XXXX.md)
- Related project: [PROJECTS/XXXX](../PROJECTS/XXXX.md)

---

## Security Considerations

> This section is **required** on every PR. "No security impact" is an acceptable answer — skipping the section is not.

- Any auth, access, secret handling, or policy impacts?
- Confirm: no secrets or personal data were added in this diff
- Confirm: no `.env` files were committed

---

## Quality Gates (AI-authored content only)

If this PR includes AI-authored content (episodes, outreach drafts, posts):

- [ ] Outbound quality gate: `gate: PASS` → results: `EVALS/results/[slug]-quality.md`
- [ ] Brand voice gate: `gate: PASS` → results: `EVALS/results/[slug]-voice.md`
- [ ] Publish preflight checklist completed: `RUNBOOKS/publish-preflight.md`

*Skip this section if PR contains only code, configs, or internal-only docs.*

---

## Autonomy Risk Check

- [ ] Does this PR expand agent permissions, scope, or autonomous action in any way?
  - If checked: explain mitigation and confirm `matt@appyhourlabs.com` approval is captured here

---

## Policy Links

Link any `POLICIES/`, `PROJECTS/`, `RUNBOOKS/`, or `TASKS/` docs affected by this change:
-
