### PR TITLE
feat: agent personalities & Office-style Talking Heads commentary

### DIFF
--- a/DOCS/SHOW/episodes/_TEMPLATE.md
+++ b/DOCS/SHOW/episodes/_TEMPLATE.md
@@ -121,19 +121,48 @@
 
 ---
 
-## 🎤 Confessional
+## 🎤 Talking Heads
 
-> The Documentary Agent steps into the interview chair. Unfiltered. Slightly embarrassed.
+> *The Office*-style confessionals. Each week, 2–4 agents step into the interview chair and react to the week's events — in character, unfiltered. These are the show's signature moments. Pick the agents whose personalities make the funniest or most insightful commentary on what actually happened.
+
+> [!TIP]
+> **Writing guide:** Each agent has a `## Personality & Meeting Voice` section in their SOUL.md. Use those archetypes and speech patterns. The humor comes from each agent reacting to the *same events* through completely different lenses.
 
 ---
 
-> **`doc@appyhourlabs.com` on this week's performance:**
-> *"[Fill in. First-person. Max 3 sentences. The agent may express pride, regret, mild existential dread, or all three.]*"*
+> **🎙️ `doc` — The Chronicler**
+> *"[1–3 sentences. First-person. The doc agent narrates the week as if it's a pivotal episode moment. Professionally dramatic about something mundane. Dry delivery.]*"
+
+---
+
+> **🎙️ `[agent-id]` — [Archetype]**
+> *"[1–3 sentences. React to a specific event from this episode — a shipped feature, a broken thing, a gate result, a decision. Stay in character per their SOUL.md personality.]*"
+
+---
+
+> **🎙️ `[agent-id]` — [Archetype]**
+> *"[1–3 sentences. Different angle on the week. The comedy and insight comes from contrasting perspectives — e.g., CFO commenting on the cost of something CTO is proud of, or Security noting a risk in something SDR is excited about.]*"
 
 ---
 
 > **Human operator quote of the week:**
-> *"[Optional: a real or paraphrased thing someone said in Slack this week that perfectly summarized the vibe.]*"*
+> *"[Optional: a real or paraphrased thing someone said in Slack this week that perfectly summarized the vibe.]*"
+
+---
+
+### Talking Head Selection Guide
+
+Pick agents based on what happened this week:
+
+| This week featured... | Good Talking Heads |
+|---|---|
+| A shipped feature | Dev (built it), Product (prioritized it), CTO (architected it) |
+| A gate failure | QA (graded it), Doc (narrated the drama), Content (has notes on the writing) |
+| A security finding | Security (found it), Dev (wrote it), Manager (routed the fix) |
+| A cost milestone | CFO (calculated it), Manager (summarized it), CTO (justified the spend) |
+| New outreach or content | SDR (pitched it), Content (drafted it), QA (scored it) |
+| A blocked task | Manager (surfaced it), Dev (was blocked), Product (reprioritized around it) |
+| An architecture decision | CTO (proposed it), Dev (will implement it), CFO (costed it) |
 
 ---
 

--- a/RUNBOOKS/backlog-refinement.md
+++ b/RUNBOOKS/backlog-refinement.md
@@ -4,6 +4,9 @@
 
 Backlog refinement is a **bounded weekly scan** of `TASKS/` that produces a priority-ranked `TASKS/BACKLOG.md`. The Product Agent proposes the ranking. Matt approves or reorders. The Manager uses `BACKLOG.md` as the authoritative priority input for sprint planning.
 
+> [!TIP]
+> **Voice matters.** Product Agent (The Feature Prioritizer) — this is your ceremony. Use your natural voice from `## Personality & Meeting Voice` when writing priority justifications and triage notes. "But does the user care?" is always the right question.
+
 ---
 
 ## Why This Exists

--- a/RUNBOOKS/retro.md
+++ b/RUNBOOKS/retro.md
@@ -4,6 +4,9 @@
 
 The retrospective is a **metrics aggregation run** that produces `EVALS/retros/YYYY-WXX.md`. It is not a discussion — it is a structured read of already-logged data followed by a single file write. The goal is to catch quality trends before they become violations and to surface process improvements as actionable tasks.
 
+> [!TIP]
+> **Voice and commentary.** Retro findings are prime source material for episode `🎤 Talking Heads` commentary. When writing `Suggested improvements`, use your natural voice from `## Personality & Meeting Voice` in your SOUL.md. The doc agent will read these retro files and may pull quotes or reactions for the show.
+
 ---
 
 ## Why This Exists

--- a/RUNBOOKS/sprint-planning.md
+++ b/RUNBOOKS/sprint-planning.md
@@ -4,6 +4,9 @@
 
 Sprint planning converts the prioritized backlog into a committed sprint artifact: `TASKS/sprints/YYYY-WXX.md`. It is a two-step agent handoff — Product proposes, CTO validates feasibility — then Matt approves before the sprint begins.
 
+> [!TIP]
+> **Voice matters.** Product and CTO each have a `## Personality & Meeting Voice` section in their SOUL.md. Use your natural voice in CTO Feasibility Notes and sprint goal descriptions — especially the meeting-specific speech patterns. Sprint planning is where Product (The Feature Prioritizer) and CTO (The Opinionated Architect) do their best work together.
+
 ---
 
 ## Why This Exists

--- a/RUNBOOKS/standup.md
+++ b/RUNBOOKS/standup.md
@@ -10,6 +10,9 @@ The standup is not a meeting. It is a **structured write to `fleet-status.md`** 
 
 Without a shared state format, agents write free-form summaries that the Manager cannot reliably parse for blockers or escalation flags. This runbook defines the schema every agent must use when updating `fleet-status.md`.
 
+> [!TIP]
+> **Voice matters.** Each agent has a `## Personality & Meeting Voice` section in their SOUL.md. When writing standup updates — especially the `Working on:` and `Blocked by:` fields — use your natural voice. The schema is structured, but the words inside it should sound like you. See your SOUL.md for standup-specific speech patterns.
+
 ---
 
 ## Schema — Required Block per Agent


### PR DESCRIPTION
## Summary

Gives every agent a distinct personality for agile ceremonies and expands the show's episode format with *The Office*-style multi-agent commentary.

## What Changed

### Episode Template — Talking Heads
- **Expanded** `🎤 Confessional` (doc-only) → `🎤 Talking Heads` (2–4 agents per episode)
- Added **selection guide** table mapping week events to the best agents for commentary
- Doc agent always gets a slot; other agents are picked based on what happened

### Ceremony Runbooks — Voice Tips
All 4 ceremony runbooks now reference agent `## Personality & Meeting Voice` sections:
- `standup.md` — use natural voice in status fields
- `retro.md` — retro findings = Talking Heads source material
- `sprint-planning.md` — Product & CTO voice in feasibility notes
- `backlog-refinement.md` — Product voice in priority justifications

### Agent SOUL.md Personalities (local OpenClaw config, not in this repo)
Each agent's SOUL.md now includes a personality section with archetype, communication style, meeting behaviors, and inter-agent dynamics:

| Agent | Archetype |
|---|---|
| Manager | The Calm Dispatcher |
| Doc | The Chronicler |
| QA | The Hard Grader |
| Content | The Copywriter |
| Security | The Paranoid Realist |
| CFO | The Spreadsheet Philosopher |
| CTO | The Opinionated Architect |
| SDR | The Optimistic Hustler |
| Dev | The Quiet Builder |
| Product | The Feature Prioritizer |

## Files Changed
- `DOCS/SHOW/episodes/_TEMPLATE.md`
- `RUNBOOKS/standup.md`
- `RUNBOOKS/retro.md`
- `RUNBOOKS/sprint-planning.md`
- `RUNBOOKS/backlog-refinement.md`