### PR TITLE
docs: add CONTRIBUTING, CODE_OF_CONDUCT, and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to this project will be documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).  
+Dates use ISO 8601 (`YYYY-MM-DD`).
+
+---
+
+## [Unreleased]
+
+### Added
+- `CONTRIBUTING.md` — contributor guide for humans and AI agents
+- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
+- `CHANGELOG.md` — this file
+
+---
+
+## [0.3.0] — 2026-02-22
+
+### Added
+- Agile ceremonies runbooks for the agent fleet (`RUNBOOKS/ceremonies/`)
+- `PROJECTS/0003-agile-ceremonies-for-agent-fleet.md`
+- EvalPal mission brief (`DOCS/evalpal-mission-brief.md`)
+- Agent alignment documentation for EvalPal prep
+- Content pipeline: `DOCS/SHOW/` episodes auto-pushed by `doc` agent via PR
+
+### Changed
+- `README.md` updated to reflect 10-agent fleet and CampClaw progress (Steps 00–12)
+
+---
+
+## [0.2.0] — 2026-02-21
+
+### Added
+- Full repo scaffold: `AGENTS/`, `EVALS/`, `POLICIES/`, `RUNBOOKS/`, `TASKS/`, `PROJECTS/`, `SCHEMAS/`
+- Initial agent role definitions for all 10 agents
+- `AGENTS.md` — fleet overview and contributor context guide
+- `POLICIES/ai-safety-charter.md`, `oauth-policy.md`, `posting-policy.md`, `escalation-policy.md`, `phase-a-to-b.md`
+- `SECURITY.md` — vulnerability disclosure policy
+- `.github/CODEOWNERS`, `PULL_REQUEST_TEMPLATE.md`, issue templates (`task.md`, `project.md`)
+- CI workflow — `no-secrets.yml` (secret scanning on all PRs)
+- `CAMPCLAW.md` — CampClaw learning path tracker
+- `PROJECTS/0001-google-workspace-hardening.md`
+- `PROJECTS/0002-mac-mini-ai-office-setup.md`
+- Episodes 000–003 in `DOCS/SHOW/episodes/`
+
+---
+
+## [0.1.0] — 2026-02-21
+
+### Added
+- Repository initialized
+- `README.md` — project overview, autonomy model, team roster
+- `LICENSE` — MIT
+- `.gitignore`, `.env.example`, `Dockerfile`, `docker-compose.yml`
+- `requirements.txt`
+
+---
+
+*This changelog is maintained by the `doc` agent (`doc@appyhourlabs.com`) and reviewed by `matt@appyhourlabs.com`.*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,61 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in the AI Workforce Lab a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+**Examples of behavior that contributes to a positive environment:**
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive feedback
+- Focusing on what is best for the community and the experiment
+- Showing empathy toward community members
+
+**Examples of unacceptable behavior:**
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — GitHub issues, PRs, discussions, and any other official communication channels — and also applies when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team at **`matt@appyhourlabs.com`**. All complaints will be reviewed and investigated promptly and fairly.
+
+All maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Maintainers will follow these Community Impact Guidelines:
+
+**1. Correction** — Private written warning, clarification of the violation.
+
+**2. Warning** — A warning with consequences for continued behavior. No interaction with the people involved for a specified period.
+
+**3. Temporary Ban** — Temporary ban from any community interaction or public communication.
+
+**4. Permanent Ban** — Permanent ban from any public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+---
+
+*Last updated: 2026-02-22*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing to AI Workforce Lab
+
+> **By Appy Hour Labs** — we welcome thoughtful contributions from humans and, eventually, auditable contributions from agents.
+
+This project is a live experiment in responsible AI deployment. Contributing here means joining that experiment, paper trail and all.
+
+---
+
+## Before You Do Anything
+
+1. **Read the [AI Safety Charter](POLICIES/ai-safety-charter.md)** — it is the non-negotiable foundation for everything in this repo.
+2. **Understand the autonomy model** — we are in **Phase A**. No outbound action is taken without human approval. Ever.
+3. **Read [`AGENTS.md`](AGENTS.md)** — so you understand who (and what) is already doing work here.
+
+---
+
+## What We Welcome
+
+| Contribution type | Where it lives | Notes |
+|---|---|---|
+| Bug reports or observations | `.github/ISSUE_TEMPLATE/task.md` | Open an issue using the task template |
+| Project proposals | `.github/ISSUE_TEMPLATE/project.md` | Open an issue using the project template |
+| Documentation improvements | `DOCS/`, `RUNBOOKS/`, `POLICIES/` | Small, targeted PRs preferred |
+| New TASKS or RUNBOOKS | `TASKS/`, `RUNBOOKS/` | Follow existing naming conventions |
+| CI/workflow improvements | `.github/workflows/` | Requires security review |
+| Episode content | `DOCS/SHOW/episodes/` | Must pass quality + brand voice eval gates |
+
+---
+
+## What We Do Not Accept
+
+- **Secrets, credentials, tokens, API keys, or PII** — in any file, format, or encoding
+- **Bypasses of the PR template** — the Security Considerations section is mandatory, no exceptions
+- **Changes to `POLICIES/`** that reduce safety constraints without explicit founder approval (`matt@appyhourlabs.com`)
+- **Autonomous outbound actions** — nothing in a PR should enable agents to act externally without human review
+
+---
+
+## Contribution Workflow
+
+### 1. Find or create a task
+
+Pick an open [issue](https://github.com/AppyHourLabs/ai-workforce-lab/issues) or create one using the appropriate template. Every contribution should trace back to a task or project definition.
+
+### 2. Fork and branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b <type>/<short-description>
+```
+
+Branch naming convention:
+
+| Type | Prefix | Example |
+|---|---|---|
+| Documentation | `docs/` | `docs/contributing-guide` |
+| Features / new agents | `feat/` | `feat/sdr-agent-runbook` |
+| Bug fixes | `fix/` | `fix/ci-secret-scan-regex` |
+| Policies / governance | `policy/` | `policy/phase-b-criteria` |
+| Runbook / operational | `ops/` | `ops/session-handoff-update` |
+
+### 3. Make your changes
+
+- **Small PRs** — one concern per PR. A PR that changes 3 unrelated things will be asked to split.
+- **ISO dates only** — `YYYY-MM-DD`. Always.
+- **No trailing whitespace**, no Windows-style CRLF line endings on new files.
+- **Cross-link ruthlessly** — if your change affects a POLICY, TASK, or RUNBOOK, update those references too.
+
+### 4. Verify before opening a PR
+
+For AI-authored content (docs, episodes, posts):
+- [ ] Quality gate completed → result in `EVALS/results/`
+- [ ] Brand voice gate completed → result in `EVALS/results/`
+- [ ] Publish preflight checked → `RUNBOOKS/publish-preflight.md`
+
+For all PRs:
+- [ ] No secrets or PII introduced (run `git diff` and look carefully)
+- [ ] PR description fills in every section of the [PR template](.github/PULL_REQUEST_TEMPLATE.md)
+- [ ] Affected `POLICIES/`, `TASKS/`, or `RUNBOOKS/` docs are updated or linked
+
+### 5. Open the PR
+
+Target branch: `main`
+
+The PR template has five sections. Fill all of them. "N/A" is fine where genuinely not applicable; blank is not.
+
+---
+
+## File & Naming Conventions
+
+| Convention | Rule |
+|---|---|
+| Dates | ISO 8601 (`YYYY-MM-DD`) everywhere |
+| Task files | `TASKS/NNNN-short-description.md` (zero-padded 4 digits) |
+| Episode files | `DOCS/SHOW/episodes/NNN-slug.md` (zero-padded 3 digits) |
+| Eval results | `EVALS/results/[slug]-[gate-type].md` |
+| Headings | Sentence case (not Title Case) |
+| Line length | Soft limit 100 chars for prose, no limit for tables |
+
+---
+
+## Agent Contributors
+
+If you are an AI agent acting on behalf of Appy Hour Labs:
+
+1. Your identity and schedule must be documented in `AGENTS/[role].md`
+2. All your PRs must include your agent ID in the PR description
+3. You may **not** approve your own PRs — a human must review
+4. Your operating constraints are in your role definition; do not exceed them without an explicit task authorizing the expansion
+5. When in doubt, **stop and draft a task** rather than proceeding
+
+---
+
+## Code of Conduct
+
+We operate under the [Contributor Covenant](CODE_OF_CONDUCT.md). The short version: be direct, be honest, be kind. This is a small experiment run by real people (and some AI). Treat both accordingly.
+
+---
+
+## Getting Help
+
+- **Questions about the project?** Open a [task issue](https://github.com/AppyHourLabs/ai-workforce-lab/issues/new?template=task.md) — even meta questions are welcome.
+- **Security concerns?** Email `security@appyhourlabs.com`. See [`SECURITY.md`](SECURITY.md).
+- **Policy questions?** Reference [`POLICIES/`](POLICIES/) first, then open an issue if clarity is still needed.
+
+---
+
+*Maintained by `matt@appyhourlabs.com` · Last updated: 2026-02-22*


### PR DESCRIPTION
## Summary

Adds the three standard community health files that were missing from the repo.

- **CONTRIBUTING.md** — full contributor guide covering workflow, branch naming, file conventions, PR requirements, and a dedicated section for AI agent contributors
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1
- **CHANGELOG.md** — bootstrapped with project history to date (v0.1.0 → v0.3.0 + Unreleased)

Closes no specific task — this was identified as a gap during repo health assessment.

---

## Security Considerations

No security impact. No secrets, credentials, or PII added. No .env files committed.

---

## Quality Gates (AI-authored content only)

*N/A — documentation only, no outbound content.*

---

## Autonomy Risk Check

- [ ] Does this PR expand agent permissions, scope, or autonomous action in any way?

No — this PR adds governance documentation only.

---

## Policy Links

- [POLICIES/ai-safety-charter.md](POLICIES/ai-safety-charter.md)
- [SECURITY.md](SECURITY.md)